### PR TITLE
fq::div6 , fq6::mul and fq12::mul improvement

### DIFF
--- a/src/circuits/bn254/fq2.rs
+++ b/src/circuits/bn254/fq2.rs
@@ -205,6 +205,20 @@ impl Fq2 {
         circuit.0.extend(result);
         circuit
     }
+
+    pub fn div6(a: Wires) -> Circuit {
+        assert_eq!(a.len(), Self::N_BITS);
+        let mut circuit = Circuit::empty();
+
+        let a_c0 = a[0..Fq::N_BITS].to_vec();
+        let a_c1 = a[Fq::N_BITS..2*Fq::N_BITS].to_vec();
+
+        let wires_1 = circuit.extend(Fq::div6(a_c0));
+        let wires_2 = circuit.extend(Fq::div6(a_c1));
+        circuit.add_wires(wires_1);
+        circuit.add_wires(wires_2);
+        circuit
+    }
 }
 
 #[cfg(test)]
@@ -358,5 +372,17 @@ mod tests {
         }
         let c = fq2_from_wires(circuit.0);
         assert_eq!(c, a.frobenius_map(1));
+    }
+
+    #[test]
+    fn test_fq2_div6() {
+        let a = random_fq2();
+        let circuit = Fq2::div6(wires_set_from_fq2(a.clone()));
+        circuit.print_gate_type_counts();
+        for mut gate in circuit.1 {
+            gate.evaluate();
+        }
+        let c = fq2_from_wires(circuit.0);
+        assert_eq!(c + c + c + c + c + c , a);
     }
 }

--- a/src/circuits/bn254/fq6.rs
+++ b/src/circuits/bn254/fq6.rs
@@ -88,10 +88,9 @@ impl Fq6 {
         let a_c1 = a[Fq2::N_BITS..2*Fq2::N_BITS].to_vec();
         let a_c2 = a[2*Fq2::N_BITS..3*Fq2::N_BITS].to_vec();
 
-        let b = ark_bn254::Fq::from(1)/ark_bn254::Fq::from(6);
-        let wires_1 = circuit.extend(Fq2::mul_by_constant_fq(a_c0.clone(), b));
-        let wires_2 = circuit.extend(Fq2::mul_by_constant_fq(a_c1.clone(), b));
-        let wires_3 = circuit.extend(Fq2::mul_by_constant_fq(a_c2.clone(), b));
+        let wires_1 = circuit.extend(Fq2::div6(a_c0.clone()));
+        let wires_2 = circuit.extend(Fq2::div6(a_c1.clone()));
+        let wires_3 = circuit.extend(Fq2::div6(a_c2.clone()));
 
         circuit.add_wires(wires_1);
         circuit.add_wires(wires_2);


### PR DESCRIPTION
Fq::div(6) was written by mul_by_constant which was inefficient. Improvement on Fq::div6 improves Fq6::mul therefore Fq12::mul. Gate counts for Fq6::mul decreases from 29m to 23m and gate counts for Fq12::mul decreases from 88m to 71m.  Closes #9.